### PR TITLE
Adjust the init and terminate for folo report

### DIFF
--- a/src/main/java/org/commonjava/util/sidecar/jaxrs/PreSeedResource.java
+++ b/src/main/java/org/commonjava/util/sidecar/jaxrs/PreSeedResource.java
@@ -45,7 +45,6 @@ import java.io.InputStream;
 import java.util.Optional;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_OCTET_STREAM;
-import static org.commonjava.util.sidecar.services.ProxyConstants.ARCHIVE_DECOMPRESS_COMPLETE;
 import static org.commonjava.util.sidecar.services.ProxyConstants.PKG_TYPE_MAVEN;
 import static org.eclipse.microprofile.openapi.annotations.enums.ParameterIn.PATH;
 
@@ -85,15 +84,6 @@ public class PreSeedResource
         {
             logger.debug( "Get proxy resource for folo request: {}", path );
             return proxyService.doGet( PKG_TYPE_MAVEN, type, name, path, request );
-        }
-        if ( !archiveService.isDecompressed() )
-        {
-            boolean success = archiveService.decompressArchive();
-            bus.publish(ARCHIVE_DECOMPRESS_COMPLETE, sidecarConfig.localRepository.orElse( DEFAULT_REPO_PATH ));
-            if ( !success )
-            {
-                return proxyService.doGet( PKG_TYPE_MAVEN, type, name, path, request );
-            }
         }
         Optional<File> download = archiveService.getLocally( path );
         if ( download.isPresent() )

--- a/src/main/java/org/commonjava/util/sidecar/services/ArchiveRetrieveService.java
+++ b/src/main/java/org/commonjava/util/sidecar/services/ArchiveRetrieveService.java
@@ -79,6 +79,8 @@ public class ArchiveRetrieveService
     @Inject
     SidecarConfig sidecarConfig;
 
+    private boolean decompressSuccess;
+
     public boolean isDecompressed()
     {
         return decompressedBuilds.contains( getBuildConfigId() );
@@ -123,6 +125,13 @@ public class ArchiveRetrieveService
                                                          return false;
                                                      } );
         client = builder.build();
+
+        logger.info( "Decompress archive" );
+        if ( !isDecompressed() )
+        {
+            this.decompressSuccess = decompressArchive();
+            //bus.publish( ARCHIVE_DECOMPRESS_COMPLETE, sidecarConfig.localRepository.orElse( DEFAULT_REPO_PATH ) );
+        }
     }
 
     @PreDestroy
@@ -184,7 +193,7 @@ public class ArchiveRetrieveService
 
     public boolean shouldProxy( final String path )
     {
-        return getBuildConfigId() == null || getBuildConfigId().trim().isEmpty() || path.endsWith( MAVEN_META );
+        return getBuildConfigId() == null || getBuildConfigId().trim().isEmpty() || path.endsWith( MAVEN_META ) || !decompressSuccess;
     }
 
     public String getBuildConfigId()

--- a/src/main/java/org/commonjava/util/sidecar/services/ReportService.java
+++ b/src/main/java/org/commonjava/util/sidecar/services/ReportService.java
@@ -62,7 +62,16 @@ public class ReportService
         this.trackedContent.appendDownload(download);
     }
 
+    /**
+     * We need to send the folo report to Indy. Indy need an endpoint to accept it and call recordArtifact() for each entry.
+     * We also need somewhere to call this sendReport(). This might be when Quarkus receive the shutdown or terminate event.
+     */
+    public void sendReport()
+    {
+        // TODO
+    }
 
+/*
     @ConsumeEvent(value = ARCHIVE_DECOMPRESS_COMPLETE)
     public void readReport(String path)
     {
@@ -93,5 +102,6 @@ public class ReportService
         }
 
     }
+*/
 
 }


### PR DESCRIPTION
This pr has below changes: 
1. the decompose should happen earlier. We can not do that in the doGet, which may cause race condition (many threads calls doGet at the same time).
2. we don't put all the old records to new one, but only those are really used. So I remove the "readReport".
3. add sendReport. This is not implemented. We need somewhere to call it when the build completes ( or Quarkus terminates ). 