### PR TITLE
Implement large file streaming for proxy GET

### DIFF
--- a/src/main/java/org/commonjava/util/sidecar/services/ProxyService.java
+++ b/src/main/java/org/commonjava/util/sidecar/services/ProxyService.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.IOUtils;
 import org.commonjava.util.sidecar.config.ProxyConfiguration;
 import org.commonjava.util.sidecar.interceptor.ExceptionHandler;
 import org.commonjava.util.sidecar.interceptor.MetricsHandler;
+import org.commonjava.util.sidecar.util.BufferStreamingOutput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -206,8 +208,8 @@ public class ProxyService
         } );
         if ( resp.body() != null )
         {
-            byte[] bytes = resp.body().getBytes();
-            builder.entity( bytes );
+            StreamingOutput so = new BufferStreamingOutput( resp );
+            builder.entity( so );
         }
         return builder.build();
     }

--- a/src/main/java/org/commonjava/util/sidecar/util/BufferStreamingOutput.java
+++ b/src/main/java/org/commonjava/util/sidecar/util/BufferStreamingOutput.java
@@ -1,0 +1,86 @@
+package org.commonjava.util.sidecar.util;
+
+import io.vertx.mutiny.core.buffer.Buffer;
+import io.vertx.mutiny.ext.web.client.HttpResponse;
+import org.apache.commons.io.output.CountingOutputStream;
+import org.apache.commons.io.output.TeeOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.StreamingOutput;
+import javax.xml.bind.DatatypeConverter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class BufferStreamingOutput
+                implements StreamingOutput
+{
+    private static final int bufSize = 10 * 1024 * 1024;
+
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
+
+    private HttpResponse<Buffer> response;
+
+    private Supplier<OutputStream> cacheStreamSupplier;
+
+    public BufferStreamingOutput( HttpResponse<Buffer> response )
+    {
+        this.response = response;
+    }
+
+    @Override
+    public void write( OutputStream output ) throws IOException, WebApplicationException
+    {
+        OutputStream cacheStream = null;
+        try(CountingOutputStream cout = new CountingOutputStream( output ))
+        {
+            OutputStream out = cout;
+            if ( cacheStreamSupplier != null )
+            {
+                cacheStream = cacheStreamSupplier.get();
+                if ( cacheStream != null )
+                {
+                    out = new TeeOutputStream( cacheStream, output );
+                }
+            }
+
+            Buffer buffer = response.bodyAsBuffer();
+            int total = buffer.length();
+            int transferred = 0;
+            while ( transferred < total )
+            {
+                int next = bufSize < total ? bufSize : total;
+                byte[] bytes = buffer.getBytes( transferred, next );
+                out.write( bytes );
+
+                transferred = next;
+            }
+            out.flush();
+        }
+        finally
+        {
+            if ( cacheStream != null )
+            {
+                try
+                {
+                    cacheStream.close();
+                }
+                catch ( Exception e )
+                {
+                    logger.error( "Failed to close cache stream: " + e.getMessage(), e );
+                }
+            }
+        }
+    }
+
+    public void setCacheStreamSupplier( Supplier<OutputStream> cacheStreamSupplier )
+    {
+        this.cacheStreamSupplier = cacheStreamSupplier;
+    }
+}


### PR DESCRIPTION
This introduces another StreamingOutput implementation that wraps a Buffer response coming from Mutiny when we proxy a GET request for a file. This enables us to avoid buffering the whole file in memory when transferring back to the client. This is based on work in Commonjava/gateway.

**This code has NOT been tested for performance, to ensure that the memory usage problems are fixed. We need to performance test this, probably with a profiler on localhost or similar at a minimum, to ensure heap memory doesn't spike when a really large file is proxied.**

NOTE: This is a backport of the attempt to implement file streaming on the archive-enabled version of this service. I've cut out digest handling and tracking record setup to make it work in the older codebase. It's based on commit: 989c6c165741d0ec20d7b6cf8611187a9e3a9adb.