### PR TITLE
Switch otel to use environment variables to pickup trace context.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>com.redhat.resilience.otel</groupId>
+      <groupId>org.commonjava.resilience.otel</groupId>
       <artifactId>opentelemetry-ext-cli-java</artifactId>
       <version>1.0.0-SNAPSHOT</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,11 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>com.redhat.resilience.otel</groupId>
+      <artifactId>opentelemetry-ext-cli-java</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,11 @@
   <parent>
     <groupId>org.commonjava</groupId>
     <artifactId>service-parent</artifactId>
-    <version>1-SNAPSHOT</version>
+    <version>2</version>
   </parent>
   <groupId>org.commonjava.utils</groupId>
   <artifactId>sidecar</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.1-SNAPSHOT</version>
   <name>Sidecar :: Project Root</name>
   <inceptionYear>2011-2021</inceptionYear>
   <scm>
@@ -69,9 +69,9 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>org.commonjava.resilience.otel</groupId>
+      <groupId>com.redhat.resilience.otel</groupId>
       <artifactId>opentelemetry-ext-cli-java</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
+      <version>1.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,6 +11,8 @@ quarkus:
 
   opentelemetry:
     enabled: true
+    propagators:
+      - envar
     tracer:
       exporter:
         otlp:


### PR DESCRIPTION
The sidecar is intended to be run in short-lived builder pods which will inherit a trace context from the build orchestrator. This should be set on the builder pod using environment variables that are consistent with the Jenkins Opentelemetry Plugin, here:

https://github.com/jenkinsci/opentelemetry-plugin/blob/master/docs/job-traces.md#environment-variables-for-trace-context-propagation-and-integrations

They will be parsed using the same logic as the W3C trace context standard:

https://www.w3.org/TR/trace-context/#relationship-between-the-headers

To do this, we simply set the quarkus.opentelemetry.propagators configuration to include the 'envar' propagator, which is provided in the new opentelemetry-ext-cli-java dependency.