### PR TITLE
Remove resteasy config in build time

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,11 +9,11 @@ quarkus:
     port: 8080
     read-timeout: 30m
     limits:
-      max-body-size: 500M
-  resteasy:
-    gzip:
-      enabled: true
-      max-input: 1024M
+      max-body-size: 1024M
+#  resteasy:
+#    gzip:
+#      enabled: true
+#      max-input: 1024M
 
   opentelemetry:
     enabled: true


### PR DESCRIPTION
And increase the http max-body-size to 1024M