### PR TITLE
Making defaults TLS protocols to v1.2 to have better version compatibility support for npm build

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,9 @@ quarkus:
 #      certificate:
 #        file: /deployments/ssl/tls.crt
 #        key-file: /deployments/ssl/tls.key
+    # Make defaults protocols to TLS v1.2 if ssl enables,
+    # this will bring better version compatibility support for current npm build.
+#      protocols: TLSv1.2
     port: 8080
     read-timeout: 30m
     limits:


### PR DESCRIPTION
Based on the TLS connection debugging, Sidecar defaults to use v1.3 which takes precedence over v1.2, since from v1.3 TLS forbids renegotiation to prior protocols versions, it means renegotiation is not possible if TLS v1.3 has been negotiated. We don't know much more about how the TLS negotiation during npm build, but from npm perspective, it already requires to use TLS v1.2 or higher for compatibility, https://github.blog/2021-08-23-npm-registry-deprecating-tls-1-0-tls-1-1/, officially says 99% of traffic to the npm registry is already using TLS v1.2. So from our side maybe we could set the TLS version in our quarkus service to v1.2 for now, which should be the most stable version and meet our security purpose.

Issue: https://issues.redhat.com/browse/MMENG-3464