### PR TITLE
Implement sidecar streaming read to accommodate the tracking report digest computing

### DIFF
--- a/src/main/java/org/commonjava/util/sidecar/util/ProxyStreamingOutput.java
+++ b/src/main/java/org/commonjava/util/sidecar/util/ProxyStreamingOutput.java
@@ -16,52 +16,135 @@
 package org.commonjava.util.sidecar.util;
 
 import io.opentelemetry.api.trace.Span;
-import org.apache.commons.io.IOUtils;
+import okhttp3.ResponseBody;
+import okio.BufferedSource;
 import org.apache.commons.io.output.CountingOutputStream;
+import org.commonjava.util.sidecar.model.TrackedContentEntry;
+import org.commonjava.util.sidecar.services.ReportService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.core.StreamingOutput;
+import javax.xml.bind.DatatypeConverter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ProxyStreamingOutput
                 implements StreamingOutput
 {
     private final Logger logger = LoggerFactory.getLogger( getClass() );
 
-    private final InputStream bodyStream;
+    private static final String MD5 = "MD5";
+
+    private static final String SHA1 = "SHA-1";
+
+    private static final String SHA256 = "SHA-256";
+
+    private static final String[] DIGESTS = { MD5, SHA1, SHA256 };
+
+    private static final long bufSize = 10 * 1024 * 1024;
+
+    private final ResponseBody responseBody;
+
+    private final TrackedContentEntry entry;
+
+    private final String serviceOrigin;
+
+    private final String indyOrigin;
+
+    private final ReportService reportService;
 
     private final OtelAdapter otel;
 
-    public ProxyStreamingOutput( InputStream bodyStream, OtelAdapter otel )
+    private final Map<String, MessageDigest> digests = new HashMap<>();
+
+    public ProxyStreamingOutput( ResponseBody responseBody, TrackedContentEntry entry, String serviceOrigin,
+                                 String indyOrigin, ReportService reportService, OtelAdapter otel )
     {
-        this.bodyStream = bodyStream;
+        this.responseBody = responseBody;
+        this.entry = entry;
+        this.serviceOrigin = serviceOrigin;
+        this.indyOrigin = indyOrigin;
+        this.reportService = reportService;
         this.otel = otel;
+
+        for ( String key : DIGESTS )
+        {
+            try
+            {
+                digests.put( key, MessageDigest.getInstance( key ) );
+            }
+            catch ( NoSuchAlgorithmException e )
+            {
+                logger.warn( "Bytes hash calculation failed for request. Cannot get digest of type: {}", key );
+            }
+        }
     }
 
     @Override
     public void write( OutputStream output ) throws IOException
     {
-        if ( bodyStream != null )
+        if ( responseBody != null )
         {
-            try
+            try (CountingOutputStream cout = new CountingOutputStream( output ))
             {
-                OutputStream out = output;
-                CountingOutputStream cout = new CountingOutputStream( out );
-                out = cout;
-                logger.trace( "Copying from: {} to: {}", bodyStream, out );
-                IOUtils.copy( bodyStream, out );
-
+                OutputStream out = cout;
+                BufferedSource peek = responseBody.source().peek();
+                while ( !peek.exhausted() )
+                {
+                    byte[] bytes;
+                    if ( peek.request( bufSize ) )
+                    {
+                        bytes = peek.readByteArray(
+                                        bufSize ); // byteCount bytes will be removed from current buffer after read
+                    }
+                    else
+                    {
+                        bytes = peek.readByteArray();
+                    }
+                    out.write( bytes );
+                    if ( entry != null )
+                    {
+                        digests.values().forEach( d -> d.update( bytes ) );
+                    }
+                }
+                out.flush();
+                peek.close();
                 if ( otel.enabled() )
                 {
                     Span.current().setAttribute( "response.content_length", cout.getByteCount() );
                 }
+                if ( entry != null )
+                {
+                    entry.setSize( cout.getByteCount() );
+                    String[] headers = indyOrigin.split( ":" );
+                    entry.setOriginUrl(
+                                    serviceOrigin + "/api/content/" + headers[0] + "/" + headers[1] + "/" + headers[2]
+                                                    + entry.getPath() );
+                    if ( digests.containsKey( MD5 ) )
+                        entry.setMd5( DatatypeConverter.printHexBinary( digests.get( MD5 ).digest() ).toLowerCase() );
+
+                    if ( digests.containsKey( SHA1 ) )
+                        entry.setSha1( DatatypeConverter.printHexBinary( digests.get( SHA1 ).digest() ).toLowerCase() );
+
+                    if ( digests.containsKey( SHA256 ) )
+                        entry.setSha256( DatatypeConverter.printHexBinary( digests.get( SHA256 ).digest() )
+                                                          .toLowerCase() );
+
+                    reportService.appendDownload( entry );
+                }
             }
             finally
             {
-                closeBodyStream( bodyStream );
+                if ( responseBody == null )
+                {
+                    return;
+                }
+                responseBody.close();
             }
         }
         else
@@ -70,28 +153,6 @@ public class ProxyStreamingOutput
             {
                 Span.current().setAttribute( "response.content_length", 0 );
             }
-        }
-    }
-
-    private void closeBodyStream( InputStream is )
-    {
-        if ( is == null )
-        {
-            return;
-        }
-
-        try
-        {
-            is.close();
-        }
-        catch ( IOException e )
-        {
-            if ( otel.enabled() )
-            {
-                Span.current().setAttribute( "body.ignored_error_class", e.getClass().getSimpleName() );
-                Span.current().setAttribute( "body.ignored_error_class", e.getMessage() );
-            }
-            logger.trace( "Failed to close body stream in proxy response.", e );
         }
     }
 }


### PR DESCRIPTION
Update the implementation of ProxyStreamingOutput to handle ProxyService.get. We need bytes to read from the buffer to take on the responsibility for computing digest for the sidecar tracking report.
The buffer reading is different from https://github.com/Commonjava/indy-sidecar/pull/31 since we already change HTTP client into okhttp3. The okio BufferedSource could keep a buffer internally so that callers can do small reads without a performance penalty.
We could request the case from PNC to test the large streaming performance, from what I tested locally, it's stable so far.
Related bug: https://issues.redhat.com/browse/MMENG-3532