### PR TITLE
Some changes to optimize otel code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ nb-configuration.xml
 # Log file
 log
 *.log
+config

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                 expression { env.CHANGE_ID != null } // Pull request
             }
             steps {
-                sh '${M2_HOME}/bin/mvn -B -V clean verify sonar:sonar -Prun-its'
+                sh '${M2_HOME}/bin/mvn -B -V clean verify -Prun-its'
             }
         }
         stage('Load OCP Mappings') {

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,10 @@
       <artifactId>quarkus-opentelemetry-exporter-otlp</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-junit5</artifactId>
       <scope>test</scope>
@@ -138,7 +142,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>${version.plugin.compiler}</version>
         <configuration>
           <forceJavacCompilerUse>true</forceJavacCompilerUse>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+
+    <httpTestserverVersion>1.5-SNAPSHOT</httpTestserverVersion>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -132,6 +134,12 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-transport-native-epoll</artifactId>
       <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.commonjava.util</groupId>
+      <artifactId>http-testserver</artifactId>
+      <version>${httpTestserverVersion}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/src/main/java/org/commonjava/util/sidecar/services/Classifier.java
+++ b/src/main/java/org/commonjava/util/sidecar/services/Classifier.java
@@ -103,10 +103,7 @@ public class Classifier
     {
         if ( otel.enabled() )
         {
-            Span span = Span.current();
-            span.setAttribute( "service_name", "sidecar" );
-            span.setAttribute( "name", method.name() );
-            span.setAttribute( "path.ext", FilenameUtils.getExtension( path ) );
+            Span.current().setAttribute( "path.ext", FilenameUtils.getExtension( path ) );
         }
 
         ServiceConfig service = getServiceConfig( path, method );
@@ -124,16 +121,7 @@ public class Classifier
         if ( otel.enabled() )
         {
             Span span = Span.current();
-            Span.current().setAttribute( "serviced", 1 );
-            span.setAttribute( "target.host", service.host );
-            span.setAttribute( "target.port", service.port );
-            span.setAttribute( "target.method", method.name() );
-            span.setAttribute( "target.path", path );
-        }
-        if ( otel.enabled() )
-        {
-            Span span = Span.current();
-            Span.current().setAttribute( "serviced", 1 );
+            span.setAttribute( "serviced", 1 );
             span.setAttribute( "target.host", service.host );
             span.setAttribute( "target.port", service.port );
             span.setAttribute( "target.method", method.name() );
@@ -161,7 +149,7 @@ public class Classifier
         return service;
     }
 
-    private WebClientAdapter getWebClient( ServiceConfig service ) throws Exception
+    private WebClientAdapter getWebClient( ServiceConfig service )
     {
         return clientMap.computeIfAbsent( service,
                                           sc -> new WebClientAdapter( sc, proxyConfiguration, timeout, otel ) );

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,10 @@ quarkus:
     propagators:
       - envar
     tracer:
+      "resource-attributes":
+        - "service.name=indy-sidecar"
+#        - "sample.rate=0.05"
+#        - "deployment.environment=localhost"
       exporter:
         otlp:
         # This is for sending to something like opentelemetry-collector

--- a/src/test/java/org/commonjava/util/sidecar/ftest/AbstractSidecarFuncTest.java
+++ b/src/test/java/org/commonjava/util/sidecar/ftest/AbstractSidecarFuncTest.java
@@ -16,7 +16,10 @@
 package org.commonjava.util.sidecar.ftest;
 
 import org.apache.commons.io.FileUtils;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.io.File;
@@ -31,12 +34,12 @@ import static org.commonjava.util.sidecar.util.TestUtil.getBytes;
 public class AbstractSidecarFuncTest
 {
     private final String TRACKED_CONTENT = "{\n" + "\"buildConfigId\":\"9000\",\n" + "\"downloads\":\n" + "[{\n"
-                    + "    \"storeKey\" : \"maven:hosted:shared-imports\",\n"
-                    + "    \"path\" : \"/org/apache/maven/maven-core/3.0/maven-core-3.0.jar\",\n"
-                    + "    \"md5\" : \"9bd377874764a4fad7209021abfe7cf7\",\n"
-                    + "    \"sha256\" : \"ba03294ee53e7ba31838e4950f280d033c7744c6c7b31253afc75aa351fbd989\",\n"
-                    + "    \"sha1\" : \"73728ce32c9016c8bd05584301fa3ba3a6f5d20a\",\n" + "    \"size\" : 527040\n"
-                    + "  }\n" + "]}";
+            + "    \"storeKey\" : \"maven:hosted:shared-imports\",\n"
+            + "    \"path\" : \"/org/apache/maven/maven-core/3.0/maven-core-3.0.jar\",\n"
+            + "    \"md5\" : \"9bd377874764a4fad7209021abfe7cf7\",\n"
+            + "    \"sha256\" : \"ba03294ee53e7ba31838e4950f280d033c7744c6c7b31253afc75aa351fbd989\",\n"
+            + "    \"sha1\" : \"73728ce32c9016c8bd05584301fa3ba3a6f5d20a\",\n" + "    \"size\" : 527040\n" + "  }\n"
+            + "]}";
 
     private final String SUCCESS_BUILD = "9000";
 
@@ -44,8 +47,23 @@ public class AbstractSidecarFuncTest
 
     private final String PATH = "/org/apache/maven/maven-core/3.0/maven-core-3.0.jar";
 
+    protected final static ExpectationServer server = new ExpectationServer( 10028 );
+
+    @BeforeAll
+    public static void before()
+    {
+        server.start();
+    }
+
+    @AfterAll
+    public static void after()
+    {
+        server.stop();
+    }
+
     @BeforeEach
-    public void prepare() throws IOException
+    public void prepare()
+            throws IOException
     {
         deleteFiles();
         File tracked = new File( DEFAULT_REPO_PATH, SUCCESS_BUILD );

--- a/src/test/java/org/commonjava/util/sidecar/ftest/MavenDownloadContentTest.java
+++ b/src/test/java/org/commonjava/util/sidecar/ftest/MavenDownloadContentTest.java
@@ -29,7 +29,7 @@ import static javax.ws.rs.core.Response.Status.OK;
 @TestProfile( SidecarFunctionProfile.class )
 @Tag( "function" )
 public class MavenDownloadContentTest
-                extends AbstractSidecarFuncTest
+        extends AbstractSidecarFuncTest
 {
     /**
      * <b>GIVEN:</b>
@@ -51,11 +51,12 @@ public class MavenDownloadContentTest
      */
     @Test
     public void testArtifactDownloadContent()
+            throws Exception
     {
-        given().when()
-               .get( "/api/folo/track/2021/maven/hosted/shared-imports/org/apache/maven/maven-core/3.0/maven-core-3.0.jar" )
-               .then()
-               .statusCode( OK.getStatusCode() );
+        final String path =
+                "/api/folo/track/2021/maven/hosted/shared-imports/org/apache/maven/maven-core/3.0/maven-core-3.0.jar";
+        server.expect( path, OK.getStatusCode(), "" );
+        given().when().get( path ).then().statusCode( OK.getStatusCode() );
     }
 
     /**

--- a/src/test/java/org/commonjava/util/sidecar/ftest/TrackedContentDownloadTest.java
+++ b/src/test/java/org/commonjava/util/sidecar/ftest/TrackedContentDownloadTest.java
@@ -18,7 +18,10 @@ package org.commonjava.util.sidecar.ftest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.RestAssured;
+import org.commonjava.test.http.expect.ExpectationServer;
 import org.commonjava.util.sidecar.ftest.profile.SidecarFunctionProfile;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +37,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 @TestProfile( SidecarFunctionProfile.class )
 @Tag( "function" )
 public class TrackedContentDownloadTest
-                extends AbstractSidecarFuncTest
+        extends AbstractSidecarFuncTest
 {
     /**
      * <b>GIVEN:</b>
@@ -56,7 +59,10 @@ public class TrackedContentDownloadTest
      */
     @Test
     public void testTrackedFileDownloadContent()
+            throws Exception
     {
+        final String path = "/api/folo/track/2021/maven/hosted/shared-imports/9000";
+        server.expect( path, OK.getStatusCode(), "" );
         RestAssured.registerParser( "application/octet-stream", JSON );
         given().when()
                .get( "/api/folo/track/2021/maven/hosted/shared-imports/9000" )

--- a/src/test/java/org/commonjava/util/sidecar/jaxrs/AbstractJaxRsTest.java
+++ b/src/test/java/org/commonjava/util/sidecar/jaxrs/AbstractJaxRsTest.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.util.sidecar.jaxrs;
+
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+public abstract class AbstractJaxRsTest
+{
+    protected final static ExpectationServer server = new ExpectationServer( 10028 );
+
+    @BeforeAll
+    public static void before()
+    {
+        server.start();
+    }
+
+    @AfterAll
+    public static void after()
+    {
+        server.stop();
+    }
+}

--- a/src/test/java/org/commonjava/util/sidecar/jaxrs/MavenDownloadFromArchiveTest.java
+++ b/src/test/java/org/commonjava/util/sidecar/jaxrs/MavenDownloadFromArchiveTest.java
@@ -17,7 +17,10 @@ package org.commonjava.util.sidecar.jaxrs;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import org.commonjava.test.http.expect.ExpectationServer;
 import org.commonjava.util.sidecar.jaxrs.mock.MockTestProfile;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -27,6 +30,7 @@ import static javax.ws.rs.core.Response.Status.OK;
 @QuarkusTest
 @TestProfile( MockTestProfile.class )
 public class MavenDownloadFromArchiveTest
+        extends AbstractJaxRsTest
 {
 
     @Test
@@ -41,7 +45,10 @@ public class MavenDownloadFromArchiveTest
 
     @Test
     public void testDownloadSuccess()
+            throws Exception
     {
+        final String path = "/api/folo/track/2021/maven/group/repo1/org/apache/maven/maven-core/3.0/maven-core-3.0.jar";
+        server.expect( path, OK.getStatusCode(), "" );
         given().when()
                .get( "/api/folo/track/2021/maven/group/repo1/org/apache/maven/maven-core/3.0/maven-core-3.0.jar" )
                .then()

--- a/src/test/java/org/commonjava/util/sidecar/jaxrs/NPMDownloadFromArchiveTest.java
+++ b/src/test/java/org/commonjava/util/sidecar/jaxrs/NPMDownloadFromArchiveTest.java
@@ -17,7 +17,10 @@ package org.commonjava.util.sidecar.jaxrs;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import org.commonjava.test.http.expect.ExpectationServer;
 import org.commonjava.util.sidecar.jaxrs.mock.MockTestProfile;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -27,8 +30,8 @@ import static javax.ws.rs.core.Response.Status.OK;
 @QuarkusTest
 @TestProfile( MockTestProfile.class )
 public class NPMDownloadFromArchiveTest
+        extends AbstractJaxRsTest
 {
-
     @Test
     public void testMetadataDownload()
     {
@@ -41,7 +44,10 @@ public class NPMDownloadFromArchiveTest
 
     @Test
     public void testDownloadSuccess()
+            throws Exception
     {
+        final String path = "/api/folo/track/2021/npm/group/npmjs/@babel/code-frame/-/code-frame-7.tgz";
+        server.expect( path, OK.getStatusCode(), "" );
         given().when()
                .get( "/api/folo/track/2021/npm/group/npmjs/@babel/code-frame/-/code-frame-7.tgz" )
                .then()

--- a/src/test/resources/proxy.yaml
+++ b/src/test/resources/proxy.yaml
@@ -5,7 +5,7 @@ proxy:
     interval: 3000
     maxBackOff: 15000
   services:
-    - host: indy-master-devel.psi.redhat.com
+    - host: localhost
       ssl: false
-      port: 80
+      port: 10028
       path-pattern: /api/.+


### PR DESCRIPTION
  * Import opentelemetry-api as direct dependency
  * Remove "service_name" span attribute as it can be specified in
    opentelemetry configurations
  * Remove some duplicate span attribute settings in Classifier
  * Use CDI injection for Otel instance getting
  * Change test code to avoid depending on remote server